### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Svelte Claude Skills
 
+[![Run in Smithery](https://smithery.ai/badge/skills/spences10)](https://smithery.ai/skills?ns=spences10&utm_source=github&utm_medium=badge)
+
+
 A curated collection of [Claude Code](https://claude.com/claude-code)
 skills for Svelte 5 and SvelteKit development. These skills provide
 context-aware guidance, best practices, and common patterns to help


### PR DESCRIPTION
## Add skill discoverability badge

Your 21 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/spences10)](https://smithery.ai/skills?ns=spences10&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.